### PR TITLE
catch json parsing errors

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -106,10 +106,15 @@ Protocol.prototype._cancel = function(){
 };
 
 Protocol.prototype._parseBuffer = function(){
-	var jsonString = this._buffer.toString('utf-8'),
-		data = JSON.parse(jsonString);
+	try {
+		var jsonString = this._buffer.toString('utf-8'),
+			data = JSON.parse(jsonString);
+		this._emitter.emit('data', data);
 
-	this._emitter.emit('data', data);
+	} catch (e) {
+		this._emitter.emit('error', e);
+	}
+
 	this._bufferLength = 0; // reset buffer
 };
 


### PR DESCRIPTION
This allows to catch syntax errors in the json string. For example if the client just sends "undefined" in the body.
